### PR TITLE
Basic support for gas resistance

### DIFF
--- a/lib/bmp280/calc.ex
+++ b/lib/bmp280/calc.ex
@@ -6,7 +6,9 @@ defmodule BMP280.Calc do
   @type raw() :: %{
           required(:raw_pressure) => non_neg_integer(),
           required(:raw_temperature) => non_neg_integer(),
-          optional(:raw_humidity) => non_neg_integer()
+          optional(:raw_humidity) => non_neg_integer(),
+          optional(:gas_r) => non_neg_integer(),
+          optional(:gas_range_r) => non_neg_integer()
         }
 
   @doc """
@@ -18,6 +20,7 @@ defmodule BMP280.Calc do
     temp = Calibration.raw_to_temperature(cal, raw.raw_temperature)
     pressure = Calibration.raw_to_pressure(cal, temp, raw.raw_pressure)
     humidity = Calibration.raw_to_humidity(cal, temp, Map.get(raw, :raw_humidity))
+    gas_resistance = Calibration.raw_to_gas_resistance(cal, raw[:gas_r], raw[:gas_range_r])
 
     # Derived calculations
     altitude = pressure_to_altitude(pressure, sea_level_pa)
@@ -29,6 +32,7 @@ defmodule BMP280.Calc do
       altitude_m: altitude,
       humidity_rh: humidity,
       dew_point_c: dew_point,
+      gas_resistance_ohms: gas_resistance,
       timestamp_ms: System.monotonic_time(:millisecond)
     }
   end

--- a/lib/bmp280/calibration.ex
+++ b/lib/bmp280/calibration.ex
@@ -4,9 +4,9 @@ defmodule BMP280.Calibration do
   @type t() :: __MODULE__.BMP280.t() | __MODULE__.BME280.t() | __MODULE__.BME680.t()
 
   @spec from_binary(BMP280.sensor_type(), binary | tuple) :: t()
-  def from_binary(:bmp280, binary), do: __MODULE__.BMP280.from_binary(binary)
-  def from_binary(:bme280, binary), do: __MODULE__.BME280.from_binary(binary)
-  def from_binary(:bme680, binary), do: __MODULE__.BME680.from_binary(binary)
+  def from_binary(sensor_type, binary) do
+    apply(calibration_module(%{type: sensor_type}), :from_binary, [binary])
+  end
 
   @spec raw_to_temperature(t(), integer()) :: float()
   def raw_to_temperature(cal, raw_temp) do
@@ -24,6 +24,15 @@ defmodule BMP280.Calibration do
       :unknown
     else
       apply(calibration_module(cal), :raw_to_humidity, [cal, temp, raw_humidity])
+    end
+  end
+
+  @spec raw_to_gas_resistance(t(), number(), number()) :: float() | :unknown
+  def raw_to_gas_resistance(cal, gas_r, gas_range_r) do
+    if cal.type == :bme680 do
+      apply(calibration_module(cal), :raw_to_gas_resistance, [cal, gas_r, gas_range_r])
+    else
+      :unknown
     end
   end
 

--- a/lib/bmp280/calibration.ex
+++ b/lib/bmp280/calibration.ex
@@ -1,207 +1,33 @@
 defmodule BMP280.Calibration do
   @moduledoc false
 
-  @type uint16() :: 0..65535
-  @type int16() :: -32768..32767
-  @type uint8() :: 0..255
-  @type int8() :: -128..127
-  @type int12() :: -2048..2047
+  @type t() :: __MODULE__.BMP280.t() | __MODULE__.BME280.t() | __MODULE__.BME680.t()
 
-  @type t() :: %{type: BMP280.sensor_type()}
-
-  @spec from_binary(BMP280.sensor_type(), <<_::192>> | <<_::248>> | tuple) ::
-          BMP280.Calibration.t()
-  def from_binary(
-        :bmp280,
-        <<dig_T1::little-16, dig_T2::little-signed-16, dig_T3::little-signed-16,
-          dig_P1::little-16, dig_P2::little-signed-16, dig_P3::little-signed-16,
-          dig_P4::little-signed-16, dig_P5::little-signed-16, dig_P6::little-signed-16,
-          dig_P7::little-signed-16, dig_P8::little-signed-16, dig_P9::little-signed-16>>
-      ) do
-    %{
-      type: :bmp280,
-      dig_T1: dig_T1,
-      dig_T2: dig_T2,
-      dig_T3: dig_T3,
-      dig_P1: dig_P1,
-      dig_P2: dig_P2,
-      dig_P3: dig_P3,
-      dig_P4: dig_P4,
-      dig_P5: dig_P5,
-      dig_P6: dig_P6,
-      dig_P7: dig_P7,
-      dig_P8: dig_P8,
-      dig_P9: dig_P9
-    }
-  end
-
-  def from_binary(
-        :bme280,
-        <<dig_T1::little-16, dig_T2::little-signed-16, dig_T3::little-signed-16,
-          dig_P1::little-16, dig_P2::little-signed-16, dig_P3::little-signed-16,
-          dig_P4::little-signed-16, dig_P5::little-signed-16, dig_P6::little-signed-16,
-          dig_P7::little-signed-16, dig_P8::little-signed-16, dig_P9::little-signed-16, _, dig_H1,
-          dig_H2::little-signed-16, dig_H3, dig_H4h, dig_H4l::4, dig_H5l::4, dig_H5h,
-          dig_H6::signed>>
-      ) do
-    %{
-      type: :bme280,
-      dig_T1: dig_T1,
-      dig_T2: dig_T2,
-      dig_T3: dig_T3,
-      dig_P1: dig_P1,
-      dig_P2: dig_P2,
-      dig_P3: dig_P3,
-      dig_P4: dig_P4,
-      dig_P5: dig_P5,
-      dig_P6: dig_P6,
-      dig_P7: dig_P7,
-      dig_P8: dig_P8,
-      dig_P9: dig_P9,
-      dig_H1: dig_H1,
-      dig_H2: dig_H2,
-      dig_H3: dig_H3,
-      dig_H4: dig_H4h * 16 + dig_H4l,
-      dig_H5: dig_H5h * 16 + dig_H5l,
-      dig_H6: dig_H6
-    }
-  end
-
-  def from_binary(
-        :bme680,
-        {res_heat_val, res_heat_range, range_switching_error,
-         <<par_t2::little-signed-16, par_t3::signed, _skip8D, par_p1::little-16,
-           par_p2::little-signed-16, par_p3::signed, _skip93, par_p4::little-signed-16,
-           par_p5::little-signed-16, par_p7::signed, par_p6::signed, _skip9A, _skip9B,
-           par_p8::little-signed-16, par_p9::little-signed-16, par_p10>>,
-         <<par_h2h, par_h2l::4, par_h1l::4, par_h1h, par_h3::signed, par_h4::signed,
-           par_h5::signed, par_h6, par_h7::signed, par_t1::little-16, par_gh2::little-signed-16,
-           par_gh1::signed, par_gh3::signed>>}
-      ) do
-    %{
-      type: :bme680,
-      par_t1: par_t1,
-      par_t2: par_t2,
-      par_t3: par_t3,
-      par_p1: par_p1,
-      par_p2: par_p2,
-      par_p3: par_p3,
-      par_p4: par_p4,
-      par_p5: par_p5,
-      par_p6: par_p6,
-      par_p7: par_p7,
-      par_p8: par_p8,
-      par_p9: par_p9,
-      par_p10: par_p10,
-      par_h1: par_h1h * 16 + par_h1l,
-      par_h2: par_h2h * 16 + par_h2l,
-      par_h3: par_h3,
-      par_h4: par_h4,
-      par_h5: par_h5,
-      par_h6: par_h6,
-      par_h7: par_h7,
-      par_gh1: par_gh1,
-      par_gh2: par_gh2,
-      par_gh3: par_gh3,
-      res_heat_val: res_heat_val,
-      res_heat_range: res_heat_range,
-      range_switching_error: range_switching_error
-    }
-  end
+  @spec from_binary(BMP280.sensor_type(), binary | tuple) :: t()
+  def from_binary(:bmp280, binary), do: __MODULE__.BMP280.from_binary(binary)
+  def from_binary(:bme280, binary), do: __MODULE__.BME280.from_binary(binary)
+  def from_binary(:bme680, binary), do: __MODULE__.BME680.from_binary(binary)
 
   @spec raw_to_temperature(t(), integer()) :: float()
-  def raw_to_temperature(%{type: :bme680} = cal, raw_temp) do
-    var1 = (raw_temp / 16384 - cal.par_t1 / 1024) * cal.par_t2
-
-    var2 =
-      (raw_temp / 131_072 - cal.par_t1 / 8192) * (raw_temp / 131_072 - cal.par_t1 / 8192) *
-        cal.par_t3 * 16
-
-    (var1 + var2) / 5120
-  end
-
-  def raw_to_temperature(%{type: sensor} = cal, raw_temp) when sensor in [:bme280, :bmp280] do
-    var1 = (raw_temp / 16384 - cal.dig_T1 / 1024) * cal.dig_T2
-
-    var2 =
-      (raw_temp / 131_072 - cal.dig_T1 / 8192) * (raw_temp / 131_072 - cal.dig_T1 / 8192) *
-        cal.dig_T3
-
-    (var1 + var2) / 5120
+  def raw_to_temperature(cal, raw_temp) do
+    apply(calibration_module(cal), :raw_to_temperature, [cal, raw_temp])
   end
 
   @spec raw_to_pressure(t(), number(), integer()) :: float()
-  def raw_to_pressure(%{type: :bme680} = cal, temp, raw_pressure) do
-    t_fine = temp * 5120
-
-    var1 = t_fine / 2 - 64000
-    var2 = var1 * var1 * cal.par_p6 / 131_072
-    var2 = var2 + var1 * cal.par_p5 * 2
-    var2 = var2 / 4 + cal.par_p4 * 65536
-    var1 = (cal.par_p3 * var1 * var1 / 16384 + cal.par_p2 * var1) / 524_288
-    var1 = (1 + var1 / 32768) * cal.par_p1
-    press_comp = 1_048_576 - raw_pressure
-    press_comp = (press_comp - var2 / 4096) * 6250 / var1
-    var1 = cal.par_p9 * press_comp * press_comp / 2_147_483_648
-    var2 = press_comp * cal.par_p8 / 32768
-    var3 = press_comp / 256 * press_comp / 256 * press_comp / 256 * cal.par_p10 / 131_072
-
-    press_comp + (var1 + var2 + var3 + cal.par_p7 * 128) / 16
-  end
-
-  def raw_to_pressure(%{type: sensor} = cal, temp, raw_pressure)
-      when sensor in [:bme280, :bmp280] do
-    t_fine = temp * 5120
-
-    var1 = t_fine / 2 - 64000
-    var2 = var1 * var1 * cal.dig_P6 / 32768
-    var2 = var2 + var1 * cal.dig_P5 * 2
-    var2 = var2 / 4 + cal.dig_P4 * 65536
-    var1 = (cal.dig_P3 * var1 * var1 / 524_288 + cal.dig_P2 * var1) / 524_288
-    var1 = (1 + var1 / 32768) * cal.dig_P1
-    p = 1_048_576 - raw_pressure
-    p = (p - var2 / 4096) * 6250 / var1
-    var1 = cal.dig_P9 * p * p / 2_147_483_648
-    var2 = p * cal.dig_P8 / 32768
-    p = p + (var1 + var2 + cal.dig_P7) / 16
-
-    p
+  def raw_to_pressure(cal, temp, raw_pressure) do
+    apply(calibration_module(cal), :raw_to_pressure, [cal, temp, raw_pressure])
   end
 
   @spec raw_to_humidity(t(), number(), integer()) :: float() | :unknown
-  def raw_to_humidity(%{type: :bme280} = cal, temp, raw_humidity)
-      when is_integer(raw_humidity) do
-    t_fine = temp * 5120
-    var_H = t_fine - 76800
-
-    var_H =
-      (raw_humidity - (cal.dig_H4 * 64 + cal.dig_H5 / 16384 * var_H)) *
-        (cal.dig_H2 / 65536 *
-           (1 +
-              cal.dig_H6 / 67_108_864 * var_H *
-                (1 + cal.dig_H3 / 67_108_864 * var_H)))
-
-    var_H = var_H * (1 - cal.dig_H1 * var_H / 524_288)
-
-    min(100, max(0, var_H))
+  def raw_to_humidity(cal, temp, raw_humidity) do
+    if cal.type == :bmp280 do
+      :unknown
+    else
+      apply(calibration_module(cal), :raw_to_humidity, [cal, temp, raw_humidity])
+    end
   end
 
-  def raw_to_humidity(%{type: :bme680} = cal, temp, hum_adc) when is_integer(hum_adc) do
-    var1 = hum_adc - (cal.par_h1 * 16 + cal.par_h3 / 2 * temp)
-
-    var2 =
-      var1 *
-        (cal.par_h2 / 262_144 *
-           (1 +
-              cal.par_h4 / 16384 *
-                temp + cal.par_h5 / 1_048_576 * temp * temp))
-
-    var3 = cal.par_h6 / 16384
-    var4 = cal.par_h7 / 2_097_152
-    h = var2 + (var3 + var4 * temp) * var2 * var2
-
-    min(100, max(0, h))
-  end
-
-  def raw_to_humidity(_cal, _temp, _raw), do: :unknown
+  defp calibration_module(%{type: :bmp280}), do: __MODULE__.BMP280
+  defp calibration_module(%{type: :bme280}), do: __MODULE__.BME280
+  defp calibration_module(%{type: :bme680}), do: __MODULE__.BME680
 end

--- a/lib/bmp280/calibration/bme280.ex
+++ b/lib/bmp280/calibration/bme280.ex
@@ -1,0 +1,104 @@
+defmodule BMP280.Calibration.BME280 do
+  @moduledoc false
+
+  @type t() :: %{
+          type: :bme280,
+          dig_T1: char,
+          dig_T2: integer,
+          dig_T3: integer,
+          dig_P1: char,
+          dig_P2: integer,
+          dig_P3: integer,
+          dig_P4: integer,
+          dig_P5: integer,
+          dig_P6: integer,
+          dig_P7: integer,
+          dig_P8: integer,
+          dig_P9: integer,
+          dig_H1: byte,
+          dig_H2: integer,
+          dig_H3: byte,
+          dig_H4: non_neg_integer,
+          dig_H5: non_neg_integer,
+          dig_H6: integer
+        }
+
+  @spec from_binary(<<_::264>>) :: t()
+  def from_binary(
+        <<dig_T1::little-16, dig_T2::little-signed-16, dig_T3::little-signed-16,
+          dig_P1::little-16, dig_P2::little-signed-16, dig_P3::little-signed-16,
+          dig_P4::little-signed-16, dig_P5::little-signed-16, dig_P6::little-signed-16,
+          dig_P7::little-signed-16, dig_P8::little-signed-16, dig_P9::little-signed-16, _, dig_H1,
+          dig_H2::little-signed-16, dig_H3, dig_H4h, dig_H4l::4, dig_H5l::4, dig_H5h,
+          dig_H6::signed>>
+      ) do
+    %{
+      type: :bme280,
+      dig_T1: dig_T1,
+      dig_T2: dig_T2,
+      dig_T3: dig_T3,
+      dig_P1: dig_P1,
+      dig_P2: dig_P2,
+      dig_P3: dig_P3,
+      dig_P4: dig_P4,
+      dig_P5: dig_P5,
+      dig_P6: dig_P6,
+      dig_P7: dig_P7,
+      dig_P8: dig_P8,
+      dig_P9: dig_P9,
+      dig_H1: dig_H1,
+      dig_H2: dig_H2,
+      dig_H3: dig_H3,
+      dig_H4: dig_H4h * 16 + dig_H4l,
+      dig_H5: dig_H5h * 16 + dig_H5l,
+      dig_H6: dig_H6
+    }
+  end
+
+  @spec raw_to_temperature(t(), integer()) :: float()
+  def raw_to_temperature(cal, raw_temp) do
+    var1 = (raw_temp / 16384 - cal.dig_T1 / 1024) * cal.dig_T2
+
+    var2 =
+      (raw_temp / 131_072 - cal.dig_T1 / 8192) * (raw_temp / 131_072 - cal.dig_T1 / 8192) *
+        cal.dig_T3
+
+    (var1 + var2) / 5120
+  end
+
+  @spec raw_to_pressure(t(), number(), integer()) :: float()
+  def raw_to_pressure(cal, temp, raw_pressure) do
+    t_fine = temp * 5120
+
+    var1 = t_fine / 2 - 64000
+    var2 = var1 * var1 * cal.dig_P6 / 32768
+    var2 = var2 + var1 * cal.dig_P5 * 2
+    var2 = var2 / 4 + cal.dig_P4 * 65536
+    var1 = (cal.dig_P3 * var1 * var1 / 524_288 + cal.dig_P2 * var1) / 524_288
+    var1 = (1 + var1 / 32768) * cal.dig_P1
+    p = 1_048_576 - raw_pressure
+    p = (p - var2 / 4096) * 6250 / var1
+    var1 = cal.dig_P9 * p * p / 2_147_483_648
+    var2 = p * cal.dig_P8 / 32768
+    p = p + (var1 + var2 + cal.dig_P7) / 16
+
+    p
+  end
+
+  @spec raw_to_humidity(t(), number(), integer()) :: float()
+  def raw_to_humidity(cal, temp, raw_humidity) do
+    t_fine = temp * 5120
+    var_H = t_fine - 76800
+
+    var_H =
+      (raw_humidity - (cal.dig_H4 * 64 + cal.dig_H5 / 16384 * var_H)) *
+        (cal.dig_H2 / 65536 *
+           (1 +
+              cal.dig_H6 / 67_108_864 * var_H *
+                (1 + cal.dig_H3 / 67_108_864 * var_H)))
+
+    var_H = var_H * (1 - cal.dig_H1 * var_H / 524_288)
+
+    min(100, max(0, var_H))
+  end
+end

--- a/lib/bmp280/calibration/bme680.ex
+++ b/lib/bmp280/calibration/bme680.ex
@@ -1,0 +1,123 @@
+defmodule BMP280.Calibration.BME680 do
+  @moduledoc false
+
+  @type t() :: %{
+          type: :bme680,
+          par_t1: integer,
+          par_t2: integer,
+          par_t3: integer,
+          par_p1: integer,
+          par_p2: integer,
+          par_p3: integer,
+          par_p4: integer,
+          par_p5: integer,
+          par_p6: integer,
+          par_p7: integer,
+          par_p8: integer,
+          par_p9: integer,
+          par_p10: integer,
+          par_h1: integer,
+          par_h2: integer,
+          par_h3: integer,
+          par_h4: integer,
+          par_h5: integer,
+          par_h6: integer,
+          par_h7: integer,
+          par_gh1: integer,
+          par_gh2: integer,
+          par_gh3: integer,
+          range_switching_error: integer,
+          res_heat_range: integer,
+          res_heat_val: integer
+        }
+
+  @spec from_binary({integer(), integer(), integer(), <<_::184>>, <<_::112>>}) :: t()
+  def from_binary(
+        {res_heat_val, res_heat_range, range_switching_error,
+         <<par_t2::little-signed-16, par_t3::signed, _skip8D, par_p1::little-16,
+           par_p2::little-signed-16, par_p3::signed, _skip93, par_p4::little-signed-16,
+           par_p5::little-signed-16, par_p7::signed, par_p6::signed, _skip9A, _skip9B,
+           par_p8::little-signed-16, par_p9::little-signed-16, par_p10>>,
+         <<par_h2h, par_h2l::4, par_h1l::4, par_h1h, par_h3::signed, par_h4::signed,
+           par_h5::signed, par_h6, par_h7::signed, par_t1::little-16, par_gh2::little-signed-16,
+           par_gh1::signed, par_gh3::signed>>}
+      ) do
+    %{
+      type: :bme680,
+      par_t1: par_t1,
+      par_t2: par_t2,
+      par_t3: par_t3,
+      par_p1: par_p1,
+      par_p2: par_p2,
+      par_p3: par_p3,
+      par_p4: par_p4,
+      par_p5: par_p5,
+      par_p6: par_p6,
+      par_p7: par_p7,
+      par_p8: par_p8,
+      par_p9: par_p9,
+      par_p10: par_p10,
+      par_h1: par_h1h * 16 + par_h1l,
+      par_h2: par_h2h * 16 + par_h2l,
+      par_h3: par_h3,
+      par_h4: par_h4,
+      par_h5: par_h5,
+      par_h6: par_h6,
+      par_h7: par_h7,
+      par_gh1: par_gh1,
+      par_gh2: par_gh2,
+      par_gh3: par_gh3,
+      range_switching_error: range_switching_error,
+      res_heat_range: res_heat_range,
+      res_heat_val: res_heat_val
+    }
+  end
+
+  @spec raw_to_temperature(t(), integer()) :: float()
+  def raw_to_temperature(cal, raw_temp) do
+    var1 = (raw_temp / 16384 - cal.par_t1 / 1024) * cal.par_t2
+
+    var2 =
+      (raw_temp / 131_072 - cal.par_t1 / 8192) * (raw_temp / 131_072 - cal.par_t1 / 8192) *
+        cal.par_t3 * 16
+
+    (var1 + var2) / 5120
+  end
+
+  @spec raw_to_pressure(t(), number(), integer()) :: float()
+  def raw_to_pressure(cal, temp, raw_pressure) do
+    t_fine = temp * 5120
+
+    var1 = t_fine / 2 - 64000
+    var2 = var1 * var1 * cal.par_p6 / 131_072
+    var2 = var2 + var1 * cal.par_p5 * 2
+    var2 = var2 / 4 + cal.par_p4 * 65536
+    var1 = (cal.par_p3 * var1 * var1 / 16384 + cal.par_p2 * var1) / 524_288
+    var1 = (1 + var1 / 32768) * cal.par_p1
+    press_comp = 1_048_576 - raw_pressure
+    press_comp = (press_comp - var2 / 4096) * 6250 / var1
+    var1 = cal.par_p9 * press_comp * press_comp / 2_147_483_648
+    var2 = press_comp * cal.par_p8 / 32768
+    var3 = press_comp / 256 * press_comp / 256 * press_comp / 256 * cal.par_p10 / 131_072
+
+    press_comp + (var1 + var2 + var3 + cal.par_p7 * 128) / 16
+  end
+
+  @spec raw_to_humidity(t(), number(), integer()) :: float()
+  def raw_to_humidity(cal, temp, hum_adc) do
+    var1 = hum_adc - (cal.par_h1 * 16 + cal.par_h3 / 2 * temp)
+
+    var2 =
+      var1 *
+        (cal.par_h2 / 262_144 *
+           (1 +
+              cal.par_h4 / 16384 *
+                temp + cal.par_h5 / 1_048_576 * temp * temp))
+
+    var3 = cal.par_h6 / 16384
+    var4 = cal.par_h7 / 2_097_152
+    h = var2 + (var3 + var4 * temp) * var2 * var2
+
+    min(100, max(0, h))
+  end
+end

--- a/lib/bmp280/calibration/bmp280.ex
+++ b/lib/bmp280/calibration/bmp280.ex
@@ -1,0 +1,73 @@
+defmodule BMP280.Calibration.BMP280 do
+  @moduledoc false
+
+  @type t() :: %{
+          type: :bmp280,
+          dig_T1: char,
+          dig_T2: integer,
+          dig_T3: integer,
+          dig_P1: char,
+          dig_P2: integer,
+          dig_P3: integer,
+          dig_P4: integer,
+          dig_P5: integer,
+          dig_P6: integer,
+          dig_P7: integer,
+          dig_P8: integer,
+          dig_P9: integer
+        }
+
+  @spec from_binary(<<_::192>>) :: t()
+  def from_binary(
+        <<dig_T1::little-16, dig_T2::little-signed-16, dig_T3::little-signed-16,
+          dig_P1::little-16, dig_P2::little-signed-16, dig_P3::little-signed-16,
+          dig_P4::little-signed-16, dig_P5::little-signed-16, dig_P6::little-signed-16,
+          dig_P7::little-signed-16, dig_P8::little-signed-16, dig_P9::little-signed-16>>
+      ) do
+    %{
+      type: :bmp280,
+      dig_T1: dig_T1,
+      dig_T2: dig_T2,
+      dig_T3: dig_T3,
+      dig_P1: dig_P1,
+      dig_P2: dig_P2,
+      dig_P3: dig_P3,
+      dig_P4: dig_P4,
+      dig_P5: dig_P5,
+      dig_P6: dig_P6,
+      dig_P7: dig_P7,
+      dig_P8: dig_P8,
+      dig_P9: dig_P9
+    }
+  end
+
+  @spec raw_to_temperature(t(), integer()) :: float()
+  def raw_to_temperature(cal, raw_temp) do
+    var1 = (raw_temp / 16384 - cal.dig_T1 / 1024) * cal.dig_T2
+
+    var2 =
+      (raw_temp / 131_072 - cal.dig_T1 / 8192) * (raw_temp / 131_072 - cal.dig_T1 / 8192) *
+        cal.dig_T3
+
+    (var1 + var2) / 5120
+  end
+
+  @spec raw_to_pressure(t(), number(), integer()) :: float()
+  def raw_to_pressure(cal, temp, raw_pressure) do
+    t_fine = temp * 5120
+
+    var1 = t_fine / 2 - 64000
+    var2 = var1 * var1 * cal.dig_P6 / 32768
+    var2 = var2 + var1 * cal.dig_P5 * 2
+    var2 = var2 / 4 + cal.dig_P4 * 65536
+    var1 = (cal.dig_P3 * var1 * var1 / 524_288 + cal.dig_P2 * var1) / 524_288
+    var1 = (1 + var1 / 32768) * cal.dig_P1
+    p = 1_048_576 - raw_pressure
+    p = (p - var2 / 4096) * 6250 / var1
+    var1 = cal.dig_P9 * p * p / 2_147_483_648
+    var2 = p * cal.dig_P8 / 32768
+    p = p + (var1 + var2 + cal.dig_P7) / 16
+
+    p
+  end
+end

--- a/lib/bmp280/comm/bme680.ex
+++ b/lib/bmp280/comm/bme680.ex
@@ -6,33 +6,111 @@ defmodule BMP280.Comm.BME680 do
   @type raw_pressure :: 0..0xFFFFF
   @type raw_temperature :: 0..0xFFFFF
 
-  @ctrl_hum_register 0xF2
-  @ctrl_meas_register 0xF4
-  @press_msb_register 0x1F
-  @gas_r_msb 0x2A
-  @res_heat_range_register 0x02
-  @res_heat_val_register 0x00
-  @range_switching_error_register 0x04
   @calibration_block_1 0x8A
   @calibration_block_2 0xE1
+  @config_register 0x75
+  @ctrl_gas1_register 0x71
+  @ctrl_hum_register 0x72
+  @ctrl_meas_register 0x74
+  @gas_r_msb_register 0x2A
+  @gas_wait0_register 0x64
+  @press_msb_register 0x1F
+  @range_switching_error_register 0x04
+  @res_heat_range_register 0x02
+  @res_heat_val_register 0x00
+  @res_heat0_register 0x5A
 
+  @oversampling_2x 2
+  @oversampling_16x 5
+
+  @sleep_mode 0
+  @forced_mode 1
+
+  @filter_size_3 2
+
+  @spec set_sleep_mode(BMP280.Transport.t()) :: :ok | {:error, any}
+  def set_sleep_mode(transport), do: set_power_mode(transport, @sleep_mode)
+
+  @spec set_forced_mode(BMP280.Transport.t()) :: :ok | {:error, any}
+  def set_forced_mode(transport), do: set_power_mode(transport, @forced_mode)
+
+  defp set_power_mode(transport, mode) do
+    with {:ok, <<no_change::6, _mode::2>>} <- Transport.read(transport, @ctrl_meas_register, 1) do
+      Transport.write(transport, @ctrl_meas_register, <<no_change::6, mode::2>>)
+    end
+  end
+
+  @doc """
+  Set humidity oversampling, temperature oversampling and pressure oversampling to default values.
+  """
   @spec set_oversampling(Transport.t()) :: :ok | {:error, any()}
   def set_oversampling(transport) do
-    # normal
-    mode = 3
-    # x2 oversampling
-    osrs_t = 2
-    # x16 oversampling
-    osrs_p = 5
-    # x16 oversampling
-    osrs_h = 5
+    mode = @sleep_mode
+    osrs_h = @oversampling_16x
+    osrs_t = @oversampling_2x
+    osrs_p = @oversampling_16x
 
     with :ok <- Transport.write(transport, @ctrl_hum_register, <<osrs_h>>) do
+      Transport.write(transport, @ctrl_meas_register, <<osrs_t::3, osrs_p::3, mode::2>>)
+    end
+  end
+
+  @doc """
+  Set IIR filter size.
+  """
+  @spec set_filter(Transport.t()) :: :ok | {:error, any()}
+  def set_filter(transport) do
+    with {:ok, config} <- Transport.read(transport, @config_register, 1),
+         <<no_change1::3, _filter::3, no_change2::2>> <- config do
       Transport.write(
         transport,
-        @ctrl_meas_register,
-        <<osrs_t::size(3), osrs_p::size(3), mode::size(2)>>
+        @config_register,
+        <<no_change1::3, @filter_size_3::3, no_change2::2>>
       )
+    end
+  end
+
+  @spec enable_gas_sensor(Transport.t()) :: :ok | {:error, any()}
+  def enable_gas_sensor(transport), do: set_gas_status(transport, 1)
+
+  @spec disable_gas_sensor(Transport.t()) :: :ok | {:error, any()}
+  def disable_gas_sensor(transport), do: set_gas_status(transport, 0)
+
+  defp set_gas_status(transport, run_gas) do
+    with {:ok, ctrl_gas1} <- Transport.read(transport, @ctrl_gas1_register, 1),
+         <<no_change1::3, _run_gas::1, no_change2::4>> <- ctrl_gas1 do
+      Transport.write(
+        transport,
+        @ctrl_gas1_register,
+        <<no_change1::3, run_gas::1, no_change2::4>>
+      )
+    end
+  end
+
+  @doc """
+  Set gas sensor heater temperature in register code.
+  """
+  @spec set_gas_heater_temperature(Transport.t(), integer(), 0..9) :: :ok | {:error, any()}
+  def set_gas_heater_temperature(transport, heater_resistance, heater_set_point \\ 0) do
+    Transport.write(transport, @res_heat0_register + heater_set_point, <<heater_resistance>>)
+  end
+
+  @doc """
+  Set gas sensor heater dutation in register code.
+  """
+  @spec set_gas_heater_duration(Transport.t(), integer(), 0..9) :: :ok | {:error, any()}
+  def set_gas_heater_duration(transport, heater_duration, heater_set_point \\ 0) do
+    Transport.write(transport, @gas_wait0_register + heater_set_point, <<heater_duration>>)
+  end
+
+  @doc """
+  Set gas sensor conversion profile.
+  """
+  @spec set_gas_heater_profile(Transport.t(), 0..9) :: :ok | {:error, any()}
+  def set_gas_heater_profile(transport, heater_set_point) do
+    with {:ok, ctrl_gas1} <- Transport.read(transport, @ctrl_gas1_register, 1),
+         <<no_change::4, _heater_set_point::4>> <- ctrl_gas1 do
+      Transport.write(transport, @ctrl_gas1_register, <<no_change::4, heater_set_point::4>>)
     end
   end
 
@@ -50,11 +128,11 @@ defmodule BMP280.Comm.BME680 do
 
   @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, Calc.raw()}
   def read_raw_samples(transport) do
-    with {:ok, pth} <- Transport.read(transport, @press_msb_register, 8),
-         {:ok, gas} <- Transport.read(transport, @gas_r_msb, 2) do
-      <<pressure::20, _::4, temp::20, _::4, humidity::16>> = pth
-      <<gas_r::10, _::2, gas_range_r::4>> = gas
-
+    with :ok <- set_forced_mode(transport),
+         {:ok, pth} <- Transport.read(transport, @press_msb_register, 8),
+         {:ok, gas} <- Transport.read(transport, @gas_r_msb_register, 2),
+         <<pressure::20, _::4, temp::20, _::4, humidity::16>> <- pth,
+         <<gas_r::10, _::2, gas_range_r::4>> <- gas do
       {:ok,
        %{
          raw_pressure: pressure,

--- a/lib/bmp280/measurement.ex
+++ b/lib/bmp280/measurement.ex
@@ -11,6 +11,7 @@ defmodule BMP280.Measurement do
     :altitude_m,
     humidity_rh: :unknown,
     dew_point_c: :unknown,
+    gas_resistance_ohms: :unknown,
     timestamp_ms: :unknown
   ]
 
@@ -20,6 +21,7 @@ defmodule BMP280.Measurement do
           altitude_m: number(),
           humidity_rh: number() | :unknown,
           dew_point_c: number() | :unknown,
+          gas_resistance_ohms: number() | :unknown,
           timestamp_ms: number() | :unknown
         }
 end

--- a/test/bmp280/calc_test.exs
+++ b/test/bmp280/calc_test.exs
@@ -99,6 +99,7 @@ defmodule BMP280.CalcTest do
     assert_in_delta 100_391.49, measurement.pressure_pa, 0.01
     assert measurement.humidity_rh == :unknown
     assert measurement.dew_point_c == :unknown
+    assert measurement.gas_resistance_ohms == :unknown
   end
 
   test "bme280 1 calculations" do
@@ -122,13 +123,21 @@ defmodule BMP280.CalcTest do
   end
 
   test "bme680 calculations" do
-    raw = %{raw_temperature: 480_732, raw_pressure: 393_705, raw_humidity: 16820}
+    raw = %{
+      raw_temperature: 480_732,
+      raw_pressure: 393_705,
+      raw_humidity: 16820,
+      gas_r: 119,
+      gas_range_r: 12
+    }
+
     measurement = Calc.raw_to_measurement(@bme680_calibration, 100_000, raw)
 
     assert_in_delta 19.3113, measurement.temperature_c, 0.0001
     assert_in_delta 100_977.52, measurement.pressure_pa, 0.01
     assert_in_delta 25.2, measurement.humidity_rh, 0.1
     assert_in_delta -1.1, measurement.dew_point_c, 0.1
+    assert_in_delta 2308.6565, measurement.gas_resistance_ohms, 0.1
   end
 
   test "altitude calculation" do


### PR DESCRIPTION
## Description

This PR adds the capability of reading gas resistance value. I referenced to the following resources  [BoschSensortec/BME680_driver](https://github.com/BoschSensortec/BME680_driver/blob/9014031fa00a5cc1eea1498c4cd1f94ec4b8ab11/bme680.c#L964) library as well as the [data sheet section 3.4](https://cdn-shop.adafruit.com/product-files/3660/BME680.pdf).

The `BMP280.Measurement` will be like this:

```elixir
{:ok,
 %BMP280.Measurement{
   altitude_m: 99.80845853673719,
   dew_point_c: 1.8098743179175818,
   gas_resistance_ohms: 4358.471915520684,
   humidity_rh: 16.967493893888527,
   pressure_pa: 100720.59804120527,
   temperature_c: 29.437646528458572
 }}
```

## Notes

~Maybe `range_switing_error` should be taken from the calibration? Currently it is read for every measurement.~

According to [Bosche website](https://community.bosch-sensortec.com/t5/Question-and-answers/How-do-I-convert-BME680-gas-resistance-to-IAQ/qaq-p/9050), Indoor Air Quality (IAQ) is not the output of the BME680 itself, but the output of a separate product called the [Bosch Sensortec Environmental Cluster software](https://www.bosch-sensortec.com/software-tools/software/bsec/) (pre-compiled binary). As far as I can tell, the IAQ algorithm itself is not available for us.

The initialization for BME680 is quite different from BM*280's. It is explained in the following:

- https://github.com/BoschSensortec/BME68x-Sensor-API/blob/e104fe56e58dfdf4d827f1344587dba7cf45bb01/bme68x.c#L135-L164
- https://github.com/BoschSensortec/BME680_driver/blob/master/README.md#example-for-configuring-the-sensor-in-forced-mode


