### PR TITLE
Split sensor initialization and Comm into per-type

### DIFF
--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -191,19 +191,19 @@ defmodule BMP280 do
   end
 
   defp init_sensor(%{sensor_type: :bmp280} = state) do
-    with :ok <- Comm.BMP280.send_enable(state.transport),
+    with :ok <- Comm.BMP280.set_oversampling(state.transport),
          {:ok, raw} <- Comm.BMP280.read_calibration(state.transport),
          do: %{state | calibration: Calibration.from_binary(:bmp280, raw)}
   end
 
   defp init_sensor(%{sensor_type: :bme280} = state) do
-    with :ok <- Comm.BME280.send_enable(state.transport),
+    with :ok <- Comm.BME280.set_oversampling(state.transport),
          {:ok, raw} <- Comm.BME280.read_calibration(state.transport),
          do: %{state | calibration: Calibration.from_binary(:bme280, raw)}
   end
 
   defp init_sensor(%{sensor_type: :bme680} = state) do
-    with :ok <- Comm.BME680.send_enable(state.transport),
+    with :ok <- Comm.BME680.set_oversampling(state.transport),
          {:ok, raw} <- Comm.BME680.read_calibration(state.transport),
          do: %{state | calibration: Calibration.from_binary(:bme680, raw)}
   end

--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -132,8 +132,7 @@ defmodule BMP280 do
     new_state =
       state
       |> query_sensor()
-      |> send_enable()
-      |> read_calibration()
+      |> init_sensor()
 
     {:noreply, new_state}
   end
@@ -183,6 +182,24 @@ defmodule BMP280 do
       error ->
         {:reply, error, state}
     end
+  end
+
+  defp init_sensor(%{sensor_type: :bmp280} = state) do
+    state
+    |> send_enable()
+    |> read_calibration()
+  end
+
+  defp init_sensor(%{sensor_type: :bme280} = state) do
+    state
+    |> send_enable()
+    |> read_calibration()
+  end
+
+  defp init_sensor(%{sensor_type: :bme680} = state) do
+    state
+    |> send_enable()
+    |> read_calibration()
   end
 
   defp query_sensor(state) do

--- a/lib/bmp280/calibration.ex
+++ b/lib/bmp280/calibration.ex
@@ -9,7 +9,7 @@ defmodule BMP280.Calibration do
 
   @type t() :: %{type: BMP280.sensor_type()}
 
-  @spec from_binary(BMP280.sensor_type(), <<_::192>> | <<_::248>> | tuple :: BMP280.Calibration.t()
+  @spec from_binary(BMP280.sensor_type(), <<_::192>> | <<_::248>> | tuple) :: BMP280.Calibration.t()
   def from_binary(
         :bmp280,
         <<dig_T1::little-16, dig_T2::little-signed-16, dig_T3::little-signed-16,

--- a/lib/bmp280/calibration.ex
+++ b/lib/bmp280/calibration.ex
@@ -9,7 +9,7 @@ defmodule BMP280.Calibration do
 
   @type t() :: %{type: BMP280.sensor_type()}
 
-  @spec from_binary(BMP280.sensor_type(), <<_::192>> | <<_::248>>) :: BMP280.Calibration.t()
+  @spec from_binary(BMP280.sensor_type(), <<_::192>> | <<_::248>> | tuple :: BMP280.Calibration.t()
   def from_binary(
         :bmp280,
         <<dig_T1::little-16, dig_T2::little-signed-16, dig_T3::little-signed-16,

--- a/lib/bmp280/comm.ex
+++ b/lib/bmp280/comm.ex
@@ -1,24 +1,10 @@
 defmodule BMP280.Comm do
-  alias BMP280.{Calc, Transport}
+  alias BMP280.Transport
 
   @moduledoc false
 
-  @type raw_pressure :: 0..0xFFFFF
-  @type raw_temperature :: 0..0xFFFFF
-
-  @bmp280_calib00_register 0x88
-
   @id_register 0xD0
   @reset_register 0xE0
-  @bme280_calib26_register 0xE1
-  @ctrl_hum_register 0xF2
-  @ctrl_meas_register 0xF4
-  @bme280_press_msb_register 0xF7
-  @bme680_press_msb_register 0x1F
-  @bme680_gas_r_msb 0x2A
-  @bme680_range_switching_error_register 0x04
-  @bme680_calibration_block_1 0x8A
-  @bme680_calibration_block_2 0xE1
 
   @spec sensor_type(Transport.t()) :: {:ok, BMP280.sensor_type()} | {:error, any()}
   def sensor_type(transport) do
@@ -36,94 +22,8 @@ defmodule BMP280.Comm do
   @doc """
   Reset the sensor
   """
-  @spec reset(BMP280.Transport.t(), BMP280.sensor_type()) :: :ok | {:error, any}
-  def reset(transport, _sensor_type) do
+  @spec reset(BMP280.Transport.t()) :: :ok | {:error, any}
+  def reset(transport) do
     Transport.write(transport, @reset_register, <<0xB6>>)
-  end
-
-  @spec send_enable(Transport.t(), BMP280.sensor_type()) :: :ok | {:error, any()}
-  def send_enable(transport, :bme280) do
-    # x16 oversampling
-    osrs_h = 5
-
-    # Configure humidity sensing
-    with :ok <- Transport.write(transport, @ctrl_hum_register, <<osrs_h>>) do
-      # Finish by enabling the parts in common with the BMP280
-      send_enable(transport, :bmp280)
-    end
-  end
-
-  def send_enable(transport, _bmp280) do
-    # normal
-    mode = 3
-    # x2 oversampling
-    osrs_t = 2
-    # x16 oversampling
-    osrs_p = 5
-
-    Transport.write(
-      transport,
-      @ctrl_meas_register,
-      <<osrs_t::size(3), osrs_p::size(3), mode::size(2)>>
-    )
-  end
-
-  @spec read_calibration(Transport.t(), BMP280.sensor_type()) :: {:error, any} | {:ok, binary}
-  def read_calibration(transport, :bmp280) do
-    Transport.read(transport, @bmp280_calib00_register, 24)
-  end
-
-  def read_calibration(transport, :bme280) do
-    with {:ok, first_part} <- Transport.read(transport, @bmp280_calib00_register, 26),
-         {:ok, second_part} <- Transport.read(transport, @bme280_calib26_register, 7) do
-      {:ok, first_part <> second_part}
-    end
-  end
-
-  def read_calibration(transport, :bme680) do
-    with {:ok, <<rse>>} <- Transport.read(transport, @bme680_range_switching_error_register, 1),
-         {:ok, first_part} <- Transport.read(transport, @bme680_calibration_block_1, 23),
-         {:ok, second_part} <- Transport.read(transport, @bme680_calibration_block_2, 14) do
-      {:ok, {rse, first_part, second_part}}
-    end
-  end
-
-  @spec read_raw_samples(Transport.t(), BMP280.sensor_type()) ::
-          {:error, any} | {:ok, Calc.raw()}
-  def read_raw_samples(transport, :bmp280) do
-    case Transport.read(transport, @bme280_press_msb_register, 6) do
-      {:ok, <<pressure::20, _::4, temp::20, _::4>>} ->
-        {:ok, %{raw_pressure: pressure, raw_temperature: temp}}
-
-      {:error, _reason} = error ->
-        error
-    end
-  end
-
-  def read_raw_samples(transport, :bme280) do
-    case Transport.read(transport, @bme280_press_msb_register, 8) do
-      {:ok, <<pressure::20, _::4, temp::20, _::4, humidity::16>>} ->
-        {:ok, %{raw_pressure: pressure, raw_temperature: temp, raw_humidity: humidity}}
-
-      {:error, _reason} = error ->
-        error
-    end
-  end
-
-  def read_raw_samples(transport, :bme680) do
-    with {:ok, pth} <- Transport.read(transport, @bme680_press_msb_register, 8),
-         {:ok, gas} <- Transport.read(transport, @bme680_gas_r_msb, 2) do
-      <<pressure::20, _::4, temp::20, _::4, humidity::16>> = pth
-      <<gas_r::10, _::2, gas_range_r::4>> = gas
-
-      {:ok,
-       %{
-         raw_pressure: pressure,
-         raw_temperature: temp,
-         raw_humidity: humidity,
-         gas_r: gas_r,
-         gas_range_r: gas_range_r
-       }}
-    end
   end
 end

--- a/lib/bmp280/comm/bme280.ex
+++ b/lib/bmp280/comm/bme280.ex
@@ -12,8 +12,8 @@ defmodule BMP280.Comm.BME280 do
   @ctrl_meas_register 0xF4
   @press_msb_register 0xF7
 
-  @spec send_enable(Transport.t()) :: :ok | {:error, any()}
-  def send_enable(transport) do
+  @spec set_oversampling(Transport.t()) :: :ok | {:error, any()}
+  def set_oversampling(transport) do
     # normal
     mode = 3
     # x2 oversampling

--- a/lib/bmp280/comm/bme280.ex
+++ b/lib/bmp280/comm/bme280.ex
@@ -1,0 +1,53 @@
+defmodule BMP280.Comm.BME280 do
+  @moduledoc false
+
+  alias BMP280.{Calc, Transport}
+
+  @type raw_pressure :: 0..0xFFFFF
+  @type raw_temperature :: 0..0xFFFFF
+
+  @calib00_register 0x88
+  @calib26_register 0xE1
+  @ctrl_hum_register 0xF2
+  @ctrl_meas_register 0xF4
+  @press_msb_register 0xF7
+
+  @spec send_enable(Transport.t()) :: :ok | {:error, any()}
+  def send_enable(transport) do
+    # normal
+    mode = 3
+    # x2 oversampling
+    osrs_t = 2
+    # x16 oversampling
+    osrs_p = 5
+    # x16 oversampling
+    osrs_h = 5
+
+    with :ok <- Transport.write(transport, @ctrl_hum_register, <<osrs_h>>) do
+      Transport.write(
+        transport,
+        @ctrl_meas_register,
+        <<osrs_t::size(3), osrs_p::size(3), mode::size(2)>>
+      )
+    end
+  end
+
+  @spec read_calibration(Transport.t()) :: {:error, any} | {:ok, binary}
+  def read_calibration(transport) do
+    with {:ok, first_part} <- Transport.read(transport, @calib00_register, 26),
+         {:ok, second_part} <- Transport.read(transport, @calib26_register, 7) do
+      {:ok, first_part <> second_part}
+    end
+  end
+
+  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, Calc.raw()}
+  def read_raw_samples(transport) do
+    case Transport.read(transport, @press_msb_register, 8) do
+      {:ok, <<pressure::20, _::4, temp::20, _::4, humidity::16>>} ->
+        {:ok, %{raw_pressure: pressure, raw_temperature: temp, raw_humidity: humidity}}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+end

--- a/lib/bmp280/comm/bme680.ex
+++ b/lib/bmp280/comm/bme680.ex
@@ -14,8 +14,8 @@ defmodule BMP280.Comm.BME680 do
   @calibration_block_1 0x8A
   @calibration_block_2 0xE1
 
-  @spec send_enable(Transport.t()) :: :ok | {:error, any()}
-  def send_enable(transport) do
+  @spec set_oversampling(Transport.t()) :: :ok | {:error, any()}
+  def set_oversampling(transport) do
     # normal
     mode = 3
     # x2 oversampling

--- a/lib/bmp280/comm/bme680.ex
+++ b/lib/bmp280/comm/bme680.ex
@@ -1,0 +1,63 @@
+defmodule BMP280.Comm.BME680 do
+  @moduledoc false
+
+  alias BMP280.{Calc, Transport}
+
+  @type raw_pressure :: 0..0xFFFFF
+  @type raw_temperature :: 0..0xFFFFF
+
+  @ctrl_hum_register 0xF2
+  @ctrl_meas_register 0xF4
+  @press_msb_register 0x1F
+  @gas_r_msb 0x2A
+  @range_switching_error_register 0x04
+  @calibration_block_1 0x8A
+  @calibration_block_2 0xE1
+
+  @spec send_enable(Transport.t()) :: :ok | {:error, any()}
+  def send_enable(transport) do
+    # normal
+    mode = 3
+    # x2 oversampling
+    osrs_t = 2
+    # x16 oversampling
+    osrs_p = 5
+    # x16 oversampling
+    osrs_h = 5
+
+    with :ok <- Transport.write(transport, @ctrl_hum_register, <<osrs_h>>) do
+      Transport.write(
+        transport,
+        @ctrl_meas_register,
+        <<osrs_t::size(3), osrs_p::size(3), mode::size(2)>>
+      )
+    end
+  end
+
+  @spec read_calibration(Transport.t()) :: {:error, any} | {:ok, binary}
+  def read_calibration(transport) do
+    with {:ok, <<rse>>} <- Transport.read(transport, @range_switching_error_register, 1),
+         {:ok, first_part} <- Transport.read(transport, @calibration_block_1, 23),
+         {:ok, second_part} <- Transport.read(transport, @calibration_block_2, 14) do
+      {:ok, {rse, first_part, second_part}}
+    end
+  end
+
+  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, Calc.raw()}
+  def read_raw_samples(transport) do
+    with {:ok, pth} <- Transport.read(transport, @press_msb_register, 8),
+         {:ok, gas} <- Transport.read(transport, @gas_r_msb, 2) do
+      <<pressure::20, _::4, temp::20, _::4, humidity::16>> = pth
+      <<gas_r::10, _::2, gas_range_r::4>> = gas
+
+      {:ok,
+       %{
+         raw_pressure: pressure,
+         raw_temperature: temp,
+         raw_humidity: humidity,
+         gas_r: gas_r,
+         gas_range_r: gas_range_r
+       }}
+    end
+  end
+end

--- a/lib/bmp280/comm/bmp280.ex
+++ b/lib/bmp280/comm/bmp280.ex
@@ -10,8 +10,8 @@ defmodule BMP280.Comm.BMP280 do
   @ctrl_meas_register 0xF4
   @press_msb_register 0xF7
 
-  @spec send_enable(Transport.t()) :: :ok | {:error, any()}
-  def send_enable(transport) do
+  @spec set_oversampling(Transport.t()) :: :ok | {:error, any()}
+  def set_oversampling(transport) do
     # normal
     mode = 3
     # x2 oversampling

--- a/lib/bmp280/comm/bmp280.ex
+++ b/lib/bmp280/comm/bmp280.ex
@@ -1,0 +1,44 @@
+defmodule BMP280.Comm.BMP280 do
+  @moduledoc false
+
+  alias BMP280.{Calc, Transport}
+
+  @type raw_pressure :: 0..0xFFFFF
+  @type raw_temperature :: 0..0xFFFFF
+
+  @calib00_register 0x88
+  @ctrl_meas_register 0xF4
+  @press_msb_register 0xF7
+
+  @spec send_enable(Transport.t()) :: :ok | {:error, any()}
+  def send_enable(transport) do
+    # normal
+    mode = 3
+    # x2 oversampling
+    osrs_t = 2
+    # x16 oversampling
+    osrs_p = 5
+
+    Transport.write(
+      transport,
+      @ctrl_meas_register,
+      <<osrs_t::size(3), osrs_p::size(3), mode::size(2)>>
+    )
+  end
+
+  @spec read_calibration(Transport.t()) :: {:error, any} | {:ok, binary}
+  def read_calibration(transport) do
+    Transport.read(transport, @calib00_register, 24)
+  end
+
+  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, Calc.raw()}
+  def read_raw_samples(transport) do
+    case Transport.read(transport, @press_msb_register, 6) do
+      {:ok, <<pressure::20, _::4, temp::20, _::4>>} ->
+        {:ok, %{raw_pressure: pressure, raw_temperature: temp}}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+end


### PR DESCRIPTION
### Descriptioon

This is a proposal for restructuring the sensor initialization and the `Comm` module, which will make it easy for us to write per-type logic without confusion.

Currently all the sensor types are processed through a common pipeline, branching by conditinals; however, the BME680 type sensor that we will be supporting soon is quite different from the BP*280 type. It would be a good idea to secure per-type workspace before things get complicated.

Some benefits are:

- reduce the potential complexity in `Comm` when we add more features
- no need to prefix sensor types with sensor type
- reduce the risk of breaking other sensor types when updating one type

### Changes

- Split sensor initialization pipeline into per-type in the top-level module
- Split `Comm` module into per-type
- Rename `set_enable` to `set_oversampling`

### Notes

- This is refactoring only; nothing is changed at the high level.
