### PR TITLE
Add bus address validation

### DIFF
--- a/lib/bmp280/transport.ex
+++ b/lib/bmp280/transport.ex
@@ -12,19 +12,19 @@ defmodule BMP280.Transport do
   def open(bus_name, address) do
     address_hex = Integer.to_string(address, 16)
 
-    if address_exist?(address) do
-      case I2C.open(bus_name) do
-        {:ok, i2c} ->
-          Logger.info("Opened connection to address 0x#{address_hex} on bus #{bus_name}")
+    case I2C.open(bus_name) do
+      {:ok, i2c} ->
+        if address_exist?(address) do
+          Logger.info("Opened bus #{bus_name}. Address 0x#{address_hex} found.")
           {:ok, %__MODULE__{i2c: i2c, address: address}}
+        else
+          Logger.error("Address 0x#{address_hex} not found")
+          {:error, :address_not_found}
+        end
 
-        error ->
-          Logger.error("Could not connect to address 0x#{address_hex} on bus #{bus_name}")
-          error
-      end
-    else
-      Logger.error("Address 0x#{address_hex} not found")
-      {:error, :invalid_address}
+      {:error, reason} ->
+        Logger.error("Could not open bus #{bus_name} (reason: #{reason})")
+        {:error, reason}
     end
   end
 

--- a/lib/bmp280/transport.ex
+++ b/lib/bmp280/transport.ex
@@ -1,6 +1,8 @@
 defmodule BMP280.Transport do
   @moduledoc false
 
+  require Logger
+
   alias Circuits.I2C
 
   defstruct [:i2c, :address]
@@ -8,8 +10,19 @@ defmodule BMP280.Transport do
 
   @spec open(String.t(), I2C.address()) :: {:ok, t()} | {:error, any()}
   def open(bus_name, address) do
-    with {:ok, i2c} <- I2C.open(bus_name) do
-      {:ok, %__MODULE__{i2c: i2c, address: address}}
+    if address_exist?(address) do
+      case I2C.open(bus_name) do
+        {:ok, i2c} ->
+          Logger.info("Opened connection to address #{address} on bus #{bus_name}")
+          {:ok, %__MODULE__{i2c: i2c, address: address}}
+
+        error ->
+          Logger.error("Could not connect to address #{address} on bus #{bus_name}")
+          error
+      end
+    else
+      Logger.error("Address #{address} not found")
+      {:error, :invalid_address}
     end
   end
 
@@ -21,5 +34,12 @@ defmodule BMP280.Transport do
   @spec read(t(), 0..255, non_neg_integer()) :: {:ok, binary()} | {:error, any()}
   def read(transport, register, bytes_to_read) do
     I2C.write_read(transport.i2c, transport.address, <<register>>, bytes_to_read)
+  end
+
+  defp address_exist?(address) do
+    case I2C.discover_one([address]) do
+      {:ok, _} -> true
+      _ -> false
+    end
   end
 end

--- a/lib/bmp280/transport.ex
+++ b/lib/bmp280/transport.ex
@@ -10,18 +10,20 @@ defmodule BMP280.Transport do
 
   @spec open(String.t(), I2C.address()) :: {:ok, t()} | {:error, any()}
   def open(bus_name, address) do
+    address_hex = Integer.to_string(address, 16)
+
     if address_exist?(address) do
       case I2C.open(bus_name) do
         {:ok, i2c} ->
-          Logger.info("Opened connection to address #{address} on bus #{bus_name}")
+          Logger.info("Opened connection to address 0x#{address_hex} on bus #{bus_name}")
           {:ok, %__MODULE__{i2c: i2c, address: address}}
 
         error ->
-          Logger.error("Could not connect to address #{address} on bus #{bus_name}")
+          Logger.error("Could not connect to address 0x#{address_hex} on bus #{bus_name}")
           error
       end
     else
-      Logger.error("Address #{address} not found")
+      Logger.error("Address 0x#{address_hex} not found")
       {:error, :invalid_address}
     end
   end


### PR DESCRIPTION
### Description

This is a proposal for validating bus address before opening the connection.

```
iex(41)> BMP280.Transport.open("i2c-?", 0x11)
21:00:06.201 [error] Could not open bus i2c-? (reason: bus_not_found)
{:error, :bus_not_found}

iex(42)> BMP280.Transport.open("i2c-1", 0x11)
21:00:12.292 [error] Address 0x11 not found
{:error, :address_not_found}

iex(43)> BMP280.Transport.open("i2c-1", 0x77)
21:00:22.735 [info]  Opened bus i2c-1. Address 0x77 found.
{:ok,
 %BMP280.Transport{address: 119, i2c: #Reference<0.638215625.268828677.91723>}}
```

### Notes

- I do the the bus discovery or validation only within the `Transport` module because I could not think of other use cases, but if any, we could expose `discover` function.
- Since I am new to hardware development, I am not so confident in log message wording. Please feel free to change anything.