### PR TITLE
Add Transport.address type with specific addresses

### DIFF
--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -28,7 +28,7 @@ defmodule BMP280 do
   @type options() :: [
           name: GenServer.name(),
           bus_name: String.t(),
-          bus_address: Circuits.I2C.address(),
+          bus_address: Transport.address(),
           sea_level_pa: number()
         ]
 
@@ -105,7 +105,7 @@ defmodule BMP280 do
 
   The bus address is likely going to be 0x77 (the default) or 0x76.
   """
-  @spec detect(String.t(), Circuits.I2C.address()) ::
+  @spec detect(String.t(), Transport.address()) ::
           {:ok, sensor_type()} | {:error, any()}
   def detect(bus_name, bus_address \\ @default_bmp280_bus_address) do
     with {:ok, transport} <- Transport.open(bus_name, bus_address) do

--- a/lib/bmp280/transport.ex
+++ b/lib/bmp280/transport.ex
@@ -4,9 +4,10 @@ defmodule BMP280.Transport do
   alias Circuits.I2C
 
   defstruct [:i2c, :address]
-  @type t() :: %__MODULE__{i2c: I2C.bus(), address: I2C.address()}
+  @type t() :: %__MODULE__{i2c: I2C.bus(), address: address()}
+  @type address() :: 0x76 | 0x77
 
-  @spec open(String.t(), I2C.address()) :: {:ok, t()} | {:error, any()}
+  @spec open(String.t(), address()) :: {:ok, t()} | {:error, any()}
   def open(bus_name, address) do
     with {:ok, i2c} <- I2C.open(bus_name) do
       {:ok, %__MODULE__{i2c: i2c, address: address}}


### PR DESCRIPTION
This is a minor improvement for `address` type. Currently we use [`Circuits.I2C.address()` type](https://hexdocs.pm/circuits_i2c/Circuits.I2C.html#t:address/0), which can be any 7-bit address. Since our sensors only have two possible addresses `0x76` and `0x77`, we might as well be specific about them. It will likely improve the Hexdoc's links for discoverability of valid bus addresses.

### Notes

According to BME680 data sheet, 
> The 7-bit device address is 111011x. The 6 MSB bits are fixed. 