### PR TITLE
Add 1 second polling

### DIFF
--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -63,7 +63,7 @@ defmodule BMP280 do
   """
   @spec measure(GenServer.server()) :: {:ok, Measurement.t()} | {:error, any()}
   def measure(server) do
-    :sys.get_state(server).last_measurement
+    GenServer.call(server, :measure)
   end
 
   @deprecated "Use BMP280.measure/1 instead"
@@ -146,6 +146,10 @@ defmodule BMP280 do
   end
 
   @impl GenServer
+  def handle_call(:measure, _from, state) do
+    {:reply, state.last_measurement, state}
+  end
+
   def handle_call(:sensor_type, _from, state) do
     {:reply, state.sensor_type, state}
   end

--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -1,5 +1,6 @@
 defmodule BMP280 do
   use GenServer
+  require Logger
 
   alias BMP280.{Calc, Calibration, Comm, Measurement, Transport}
 
@@ -215,8 +216,9 @@ defmodule BMP280 do
 
         %{state | last_measurement: {:ok, measurement}}
 
-      error ->
-        %{state | last_measurement: error}
+      {:error, reason} ->
+        Logger.error("Error reading measurement: #{inspect(reason)}")
+        state
     end
   end
 

--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -148,7 +148,11 @@ defmodule BMP280 do
 
   @impl GenServer
   def handle_call(:measure, _from, state) do
-    {:reply, state.last_measurement, state}
+    if state.last_measurement do
+      {:reply, {:ok, state.last_measurement}, state}
+    else
+      {:reply, {:error, :no_measurement}, state}
+    end
   end
 
   def handle_call(:sensor_type, _from, state) do

--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -160,13 +160,11 @@ defmodule BMP280 do
   end
 
   def handle_call({:force_altitude, altitude_m}, _from, state) do
-    case state.last_measurement do
-      {:ok, measurement} ->
-        sea_level = Calc.sea_level_pressure(measurement.pressure_pa, altitude_m)
-        {:reply, :ok, %{state | sea_level_pa: sea_level}}
-
-      error ->
-        {:reply, error, state}
+    if state.last_measurement do
+      sea_level = Calc.sea_level_pressure(state.last_measurement.pressure_pa, altitude_m)
+      {:reply, :ok, %{state | sea_level_pa: sea_level}}
+    else
+      {:reply, {:error, :no_measurement}, state}
     end
   end
 
@@ -214,7 +212,7 @@ defmodule BMP280 do
             raw
           )
 
-        %{state | last_measurement: {:ok, measurement}}
+        %{state | last_measurement: measurement}
 
       {:error, reason} ->
         Logger.error("Error reading measurement: #{inspect(reason)}")

--- a/lib/bmp280/calc.ex
+++ b/lib/bmp280/calc.ex
@@ -28,7 +28,8 @@ defmodule BMP280.Calc do
       pressure_pa: pressure,
       altitude_m: altitude,
       humidity_rh: humidity,
-      dew_point_c: dew_point
+      dew_point_c: dew_point,
+      timestamp_ms: System.monotonic_time(:millisecond)
     }
   end
 

--- a/lib/bmp280/measurement.ex
+++ b/lib/bmp280/measurement.ex
@@ -5,13 +5,21 @@ defmodule BMP280.Measurement do
   The temperature, pressure and relative humidity measurements are computed
   directly from the sensor. All other values are derived.
   """
-  defstruct [:temperature_c, :pressure_pa, :altitude_m, :humidity_rh, :dew_point_c]
+  defstruct [
+    :temperature_c,
+    :pressure_pa,
+    :altitude_m,
+    humidity_rh: :unknown,
+    dew_point_c: :unknown,
+    timestamp_ms: :unknown
+  ]
 
   @type t :: %__MODULE__{
           temperature_c: number(),
           pressure_pa: number(),
           altitude_m: number(),
           humidity_rh: number() | :unknown,
-          dew_point_c: number() | :unknown
+          dew_point_c: number() | :unknown,
+          timestamp_ms: number() | :unknown
         }
 end


### PR DESCRIPTION
### Description

This adds one second polling for fetching data from the sensor. The last measurement will be held in the internal state. When a user invokes the `measure` function, we will simply return the last measurement stored in the state.

### Notes

- `:sys.get_state/1` seems working well and simplifies the logic. But we could alternatively write `handle_call` callback for returning last measurement.

Tested on a Nerves app (rpi0 + BME680)

```elixir
iex(11)> BMP280.read(sensor)
{:ok,
 %BMP280.Measurement{
   altitude_m: -27.237180258925797,
   dew_point_c: 2.5115408672641433,
   humidity_rh: 15.671315557037124,
   pressure_pa: 100323.29935687697,
   temperature_c: 31.700088644798235
 }}
iex(12)> BMP280.read(sensor)
{:ok,
 %BMP280.Measurement{
   altitude_m: -27.259179084657937,
   dew_point_c: 2.5156108520061315,
   humidity_rh: 15.676410092058074,
   pressure_pa: 100323.56081973035,
   temperature_c: 31.69945613989548
 }}
```