### PR TITLE
Fix gas

### DIFF
--- a/lib/bmp280/calibration/bme680_calibration.ex
+++ b/lib/bmp280/calibration/bme680_calibration.ex
@@ -40,7 +40,8 @@ defmodule BMP280.BME680Calibration do
         <<par_h2h, par_h2l::4, par_h1l::4, par_h1h, par_h3::signed, par_h4::signed,
           par_h5::signed, par_h6, par_h7::signed, par_t1::little-16, par_gh2::little-signed-16,
           par_gh1::signed, par_gh3::signed>>,
-        <<res_heat_val, _skip01, _::2, res_heat_range::2, _::4, _skip03, range_switching_error>>
+        <<res_heat_val::signed, _skip01, _::2, res_heat_range::2, _::4, _skip03,
+          range_switching_error::signed-4, _::4>>
       }) do
     %{
       type: :bme680,

--- a/lib/bmp280/comm.ex
+++ b/lib/bmp280/comm.ex
@@ -24,6 +24,7 @@ defmodule BMP280.Comm do
   """
   @spec reset(BMP280.Transport.t()) :: :ok | {:error, any}
   def reset(transport) do
-    Transport.write(transport, @reset_register, <<0xB6>>)
+    with :ok <- Transport.write(transport, @reset_register, <<0xB6>>),
+         do: Process.sleep(10)
   end
 end

--- a/lib/bmp280/sensor/bme680_sensor.ex
+++ b/lib/bmp280/sensor/bme680_sensor.ex
@@ -87,12 +87,12 @@ defmodule BMP280.BME680Sensor do
       ...>   par_gh1: -30,
       ...>   par_gh2: -5969,
       ...>   par_gh3: 18,
+      ...>   res_heat_val: 50,
       ...>   res_heat_range: 1,
-      ...>   res_heat_val: 0,
-      ...>   range_switching_error: 243
+      ...>   range_switching_error: 1
       ...> }
       iex> BME680Sensor.heater_resistance_code(cal, 300, 28)
-      131
+      112
   """
   @spec heater_resistance_code(BME680Calibration.t(), heater_temperature_c(), integer()) ::
           integer()

--- a/test/bmp280/calibration/bme680_calibration_test.exs
+++ b/test/bmp280/calibration/bme680_calibration_test.exs
@@ -37,7 +37,7 @@ defmodule BMP280.BME680CalibrationTest do
                par_gh1: -30,
                par_gh2: -5969,
                par_gh3: 18,
-               range_switching_error: 19,
+               range_switching_error: 1,
                res_heat_val: 50,
                res_heat_range: 1
              }

--- a/test/bmp280/sensor/bme680_sensor_test.exs
+++ b/test/bmp280/sensor/bme680_sensor_test.exs
@@ -28,9 +28,9 @@ defmodule BMP280.BME680SensorTest do
     par_gh1: -30,
     par_gh2: -5969,
     par_gh3: 18,
-    range_switching_error: 0,
-    res_heat_range: 0,
-    res_heat_val: 0
+    range_switching_error: 1,
+    res_heat_val: 50,
+    res_heat_range: 1
   }
 
   test "bme680 calculations" do
@@ -38,8 +38,8 @@ defmodule BMP280.BME680SensorTest do
       raw_temperature: 480_732,
       raw_pressure: 393_705,
       raw_humidity: 16820,
-      raw_gas_resistance: 195,
-      raw_gas_range: 9
+      raw_gas_resistance: 666,
+      raw_gas_range: 11
     }
 
     state = %{calibration: @bme680_calibration, sea_level_pa: 100_000}
@@ -50,6 +50,6 @@ defmodule BMP280.BME680SensorTest do
     assert_in_delta 100_977.52, measurement.pressure_pa, 0.01
     assert_in_delta 25.2, measurement.humidity_rh, 0.1
     assert_in_delta -1.1, measurement.dew_point_c, 0.1
-    assert_in_delta 20467.2644, measurement.gas_resistance_ohms, 0.0001
+    assert_in_delta 3503.6322, measurement.gas_resistance_ohms, 0.0001
   end
 end


### PR DESCRIPTION
### Description

This PR fixes a few bugs I found while refactoring the code https://github.com/fhunleth/bmp280/pull/20.

This should be merged after https://github.com/fhunleth/bmp280/pull/20.

### Problems

A lack of sleep after soft reset resulted in 0s in gas-related calibrations because they happened to be read immediately after soft reset in our code. Here are relevant section of the manufacturer's library:

- https://github.com/BoschSensortec/BME68x-Sensor-API/blob/e104fe56e58dfdf4d827f1344587dba7cf45bb01/bme68x.c#L283-L284
- https://github.com/BoschSensortec/BME68x-Sensor-API/blob/e104fe56e58dfdf4d827f1344587dba7cf45bb01/bme68x_defs.h#L104

The gas binary data types are incorrect. I overlooked the bit masks as well in a past PR. Here are relevant section of the manufacturer's library:

- https://github.com/BoschSensortec/BME68x-Sensor-API/blob/e104fe56e58dfdf4d827f1344587dba7cf45bb01/bme68x.c#L1686-L1688
- https://github.com/BoschSensortec/BME68x-Sensor-API/blob/e104fe56e58dfdf4d827f1344587dba7cf45bb01/bme68x_defs.h#L851-L858

```c
/*! Heater resistance range coefficient */
uint8_t res_heat_range;
// mask : `0x30`
// correct type: 0..3

/*! Heater resistance value coefficient */
int8_t res_heat_val;
// correct type: signed int (2 bits)

/*! Gas resistance range switching error coefficient */
int8_t range_sw_err;
// mask: `0xf0 `
// correct type: signed int (4bits)
```

### Changes

- Sleep 10ms after soft reset
- Correct data types for gas-related calibration values (`coeff3` )

### Notes

- As a consequence of this fix, my sensor says the gas resistance is ~5000 as opposed to 30,000 previously.
- This PR only affects BME680 gas resistance; not anything else.
