### PR TITLE
Improve guard for heater_duration_code

### DIFF
--- a/lib/bmp280/sensor/bme680_sensor.ex
+++ b/lib/bmp280/sensor/bme680_sensor.ex
@@ -13,7 +13,7 @@ defmodule BMP280.BME680Sensor do
           raw_gas_range: non_neg_integer()
         }
 
-  @type heater_duration_ms() :: 20..4032
+  @type heater_duration_ms() :: 1..4032
   @type heater_temperature_c() :: 200..400
 
   @heater_temperature_c 300
@@ -121,25 +121,31 @@ defmodule BMP280.BME680Sensor do
   end
 
   @doc """
-  Convert the heater duration milliseconds into a register code.
+  Convert the heater duration milliseconds into a register code. Heating durations between 1 ms and
+  4032 ms can be configured. In practice, approximately 20–30 ms are necessary for the heater to
+  reach the intended target temperature.
 
   ## Examples
 
-      iex> BME680Sensor.heater_duration_code(100)
-      89
-      iex> BME680Sensor.heater_duration_code(64)
-      80
       iex> BME680Sensor.heater_duration_code(63)
       63
+      iex> BME680Sensor.heater_duration_code(64)
+      80
+      iex> BME680Sensor.heater_duration_code(100)
+      89
+      iex> BME680Sensor.heater_duration_code(4032)
+      255
+      iex> BME680Sensor.heater_duration_code(4033)
+      ** (FunctionClauseError) no function clause matching in BMP280.BME680Sensor.heater_duration_code/2
   """
   @spec heater_duration_code(heater_duration_ms(), non_neg_integer()) :: non_neg_integer()
   def heater_duration_code(duration, factor \\ 0)
 
-  def heater_duration_code(duration, factor) when duration >= 64 do
+  def heater_duration_code(duration, factor) when duration in 64..4032 do
     duration |> div(4) |> heater_duration_code(factor + 1)
   end
 
-  def heater_duration_code(duration, factor) when duration < 64 do
+  def heater_duration_code(duration, factor) when duration in 1..63 do
     duration + factor * 64
   end
 end


### PR DESCRIPTION
### Description

This is a minor improvement for `heater_duration_code` function. Currently the range of the incoming heater duration value in ms is not restricted at runtime although it is specified in type spec. Also I realized that Elixir's range notation makes the code more readable than it is now.

Since we hardcode the heater duration value in ms to 100 in [BMP280.BME680Sensor](https://github.com/mnishiguchi/bmp280/blob/58ccc15b2421584eb65b7b3b88c706c3380e47cd/lib/bmp280/sensor/bme680_sensor.ex#L20), nothing will be changed at the high level. This is more about documenting.

### Notes

According to the data sheet (section 3.3.5):

> Heating durations between 1 ms and 4032 ms can be configured. In practice, approximately 20–30 ms are necessary for the heater to reach the intended target temperature.

The corresponding function in [BoschSensortec/BME68x-Sensor-API](https://github.com/BoschSensortec/BME68x-Sensor-API/blob/90aebea28c7c685db97b7db41b07ec78948bbf3b/bme68x.c#L1129) library enforces the max value of 255.

```c
/* This internal API is used to calculate the gas wait */
static uint8_t calc_gas_wait(uint16_t dur)
{
    uint8_t factor = 0;
    uint8_t durval;

    if (dur >= 0xfc0) // 4032
    {
        durval = 0xff; /* Max duration*/ // 255
    }
    else
    {
        while (dur > 0x3F) // 63
        {
            dur = dur / 4;
            factor += 1;
        }

        durval = (uint8_t)(dur + (factor * 64));
    }

    return durval;
}
```