### PR TITLE
Revise sensor settings

### DIFF
--- a/lib/bmp280/sensor/bme680_sensor.ex
+++ b/lib/bmp280/sensor/bme680_sensor.ex
@@ -18,7 +18,7 @@ defmodule BMP280.BME680Sensor do
 
   @heater_temperature_c 300
   @heater_duration_ms 100
-  @ambient_temperature_c 30
+  @ambient_temperature_c 25
 
   @impl true
   def init(%{transport: transport} = initial_state) do


### PR DESCRIPTION
Now that our gas support is stable, it would be nice to revise our sensor settings. The manufacturer's [latest C library](https://github.com/BoschSensortec/BME68x-Sensor-API) has all the settings configurable, but it has example implementations in the git repo. We do not have to do the same but it is a good time to check if there is any room for improvement.

### heater temperature and duration

We use the same values as the library's example.
https://github.com/BoschSensortec/BME68x-Sensor-API/blob/90aebea28c7c685db97b7db41b07ec78948bbf3b/examples/forced_mode/forced_mode.c#L58-L59

### ambient temperature

I previously picked `30` with no reason. I would change it to `25` that is used in the library's example.
https://github.com/BoschSensortec/BME68x-Sensor-API/blob/90aebea28c7c685db97b7db41b07ec78948bbf3b/examples/common/common.c#L170

### oversampling

I guess these can be any values. I wonder what can determine our oversampling settings. Here is what the example does.
https://github.com/BoschSensortec/BME68x-Sensor-API/blob/90aebea28c7c685db97b7db41b07ec78948bbf3b/examples/forced_mode/forced_mode.c#L50-L52

