### PR TITLE
Remove deprecated read/1

### DIFF
--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -78,9 +78,6 @@ defmodule BMP280 do
     GenServer.call(server, :measure)
   end
 
-  @deprecated "Use BMP280.measure/1 instead"
-  def read(server), do: measure(server)
-
   @doc """
   Update the sea level pressure estimate
 


### PR DESCRIPTION
On assumption that next release is a minor version bump, we should remove deprecated functions. Currently only `read/1` is deprecated.