### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BMP280
 
 [![Hex version](https://img.shields.io/hexpm/v/bmp280.svg "Hex version")](https://hex.pm/packages/bmp280)
-[![API docs](https://img.shields.io/hexpm/v/bmp280.svg?label=hexdocs "API docs")](https://hexdocs.pm/bmp280/SHT4X.html)
+[![API docs](https://img.shields.io/hexpm/v/bmp280.svg?label=hexdocs "API docs")](https://bmp280.hexdocs.pm/SHT4X.html)
 [![CircleCI](https://circleci.com/gh/elixir-sensors/bmp280.svg?style=svg)](https://circleci.com/gh/elixir-sensors/bmp280)
 [![REUSE status](https://api.reuse.software/badge/github.com/elixir-sensors/bmp280)](https://api.reuse.software/info/github.com/elixir-sensors/bmp280)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://bmp280.hexdocs.pm/SHT4X.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>